### PR TITLE
Avoid splitting large messages |  Make encoding configurable

### DIFF
--- a/Src/Virtual Printer Solution/VirtualPrinter/App.config
+++ b/Src/Virtual Printer Solution/VirtualPrinter/App.config
@@ -67,6 +67,9 @@
             <setting name="SendBufferSize" serializeAs="String">
                 <value>-1</value>
             </setting>
+            <setting name="ReceivedDataEncoding" serializeAs="String">
+                <value>utf-8</value>
+            </setting>
         </VirtualPrinter.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Src/Virtual Printer Solution/VirtualPrinter/Hosted Services/TcpListenerClientHandler.cs
+++ b/Src/Virtual Printer Solution/VirtualPrinter/Hosted Services/TcpListenerClientHandler.cs
@@ -1,6 +1,6 @@
 ﻿/*
  *  This file is part of Virtual ZPL Printer.
- *  
+ *
  *  Virtual ZPL Printer is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
@@ -16,6 +16,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Text;
@@ -57,67 +58,88 @@ namespace VirtualPrinter.Client
 			//
 			NetworkStream stream = client.GetStream();
 
-			while (client.Connected && stream.CanRead)
+			//
+			// Prepare a memory stream to read data into.
+			//
+			MemoryStream ms = new MemoryStream();
+
+			try
 			{
-				if (stream.DataAvailable)
+				if (client.Connected && stream.CanRead)
 				{
-					try
+					//
+					// Set up a temporary buffer.
+					//
+					byte[] data = new byte[1024];
+
+					//
+					// Read from the NetworkStream until there isn't any data to read available anymore.
+					//
+					// See https://stackoverflow.com/questions/26058594/how-to-get-all-data-from-networkstream
+					//
+					// Unfortunately, that doesn't mean that all data has necessarily been received from the client,
+					// so we could still haven't received some data after all, e.g. due to network delays. It would
+					// be better to try to read all data until the connection is terminated by the client, however,
+					// there isn't an easy way to detect a closed connection with a NetworkStream.
+					//
+					// By reading the data in small chunks, we're giving the client additional time to send
+					// data - the larger the data to be received, the more time available. Finally, by increasing
+					// the read timeout, we can further easily increase the time available to the client.
+					//
+					int numBytesRead;
+					while ((numBytesRead = stream.Read(data, 0, data.Length)) > 0)
 					{
-						//
-						// Create a buffer for the data that is available.
-						//
-						byte[] buffer = new byte[client.Available];
-
-						//
-						// Read the data into the buffer.
-						//
-						int bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length));
-
-						if (bytesRead > 0)
-						{
-							//
-							// Get the label image
-							//
-							string zpl = Encoding.UTF8.GetString(buffer);
-
-							if (!zpl.StartsWith("NOP"))
-							{
-								//
-								// Get the label images from Labelary.
-								//
-								IEnumerable<IGetLabelResponse> responses = await this.LabelService.GetLabelsAsync(labelConfiguration, zpl);
-
-								//
-								// Save the images.
-								//
-								IEnumerable<IStoredImage> storedImages = await this.ImageCacheRepository.StoreLabelImagesAsync(imagePathRoot, responses);
-
-								//
-								// Publish the images.
-								//
-								foreach (IGetLabelResponse response in responses)
-								{
-									//
-									// Publish the new label.
-									//
-									this.EventAggregator.GetEvent<LabelCreatedEvent>().Publish(new LabelCreatedEventArgs()
-									{
-										PrintRequest = new PrintRequestEventArgs()
-										{
-											LabelConfiguration = labelConfiguration,
-											Zpl = zpl
-										},
-										Label = storedImages.ElementAt(response.LabelIndex),
-										Result = response.Result,
-										Message = response.Result ? "Label successfully created." : response.Error
-									});
-								}
-							}
-						}
+					    ms.Write(data, 0, numBytesRead);
 					}
-					finally
+				}
+			}
+			finally
+			{
+				client.Close();
+			}
+
+			//
+			// Only try to create a label image if any data has been received in the first place.
+			//
+			if (ms.Length > 0)
+			{
+
+				//
+				// Get the label image.
+				//
+				string zpl = Encoding.UTF8.GetString(ms.ToArray(), 0, (int) ms.Length);
+
+				if (!zpl.StartsWith("NOP"))
+				{
+					//
+					// Get the label images from Labelary.
+					//
+					IEnumerable<IGetLabelResponse> responses = await this.LabelService.GetLabelsAsync(labelConfiguration, zpl);
+
+					//
+					// Save the images.
+					//
+					IEnumerable<IStoredImage> storedImages = await this.ImageCacheRepository.StoreLabelImagesAsync(imagePathRoot, responses);
+
+					//
+					// Publish the images.
+					//
+					foreach (IGetLabelResponse response in responses)
 					{
-						client.Close();
+						//
+						// Publish the new label.
+						//
+						this.EventAggregator.GetEvent<LabelCreatedEvent>().Publish(new LabelCreatedEventArgs()
+						{
+							PrintRequest = new PrintRequestEventArgs()
+							{
+								LabelConfiguration = labelConfiguration,
+								Zpl = zpl
+							},
+						Label = storedImages.ElementAt(response.LabelIndex),
+						Result = response.Result,
+						Message = response.Result ? "Label successfully created." : response.Error
+						});
 					}
 				}
 			}

--- a/Src/Virtual Printer Solution/VirtualPrinter/Hosted Services/TcpListenerClientHandler.cs
+++ b/Src/Virtual Printer Solution/VirtualPrinter/Hosted Services/TcpListenerClientHandler.cs
@@ -103,11 +103,25 @@ namespace VirtualPrinter.Client
 			//
 			if (ms.Length > 0)
 			{
+				//
+				// Use user-specified encoding in order to display special characters correctly.
+				//
+				Encoding encoding = Encoding.UTF8;
+				try
+				{
+					encoding = Encoding.GetEncoding(Properties.Settings.Default.ReceivedDataEncoding);
+				}
+				catch (ArgumentException ex)
+				{
+					//
+					// Simply fallback to default encoding and ignore exception.
+					//
+				}
 
 				//
 				// Get the label image.
 				//
-				string zpl = Encoding.UTF8.GetString(ms.ToArray(), 0, (int) ms.Length);
+				string zpl = encoding.GetString(ms.ToArray(), 0, (int) ms.Length);
 
 				if (!zpl.StartsWith("NOP"))
 				{

--- a/Src/Virtual Printer Solution/VirtualPrinter/Properties/Settings.Designer.cs
+++ b/Src/Virtual Printer Solution/VirtualPrinter/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace VirtualPrinter.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -260,6 +260,18 @@ namespace VirtualPrinter.Properties {
             }
             set {
                 this["SendBufferSize"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("utf-8")]
+        public string ReceivedDataEncoding {
+            get {
+                return ((string)(this["ReceivedDataEncoding"]));
+            }
+            set {
+                this["ReceivedDataEncoding"] = value;
             }
         }
     }

--- a/Src/Virtual Printer Solution/VirtualPrinter/Properties/Settings.settings
+++ b/Src/Virtual Printer Solution/VirtualPrinter/Properties/Settings.settings
@@ -62,5 +62,8 @@
     <Setting Name="SendBufferSize" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">-1</Value>
     </Setting>
+    <Setting Name="ReceivedDataEncoding" Type="System.String" Scope="User">
+      <Value Profile="(Default)">utf-8</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Src/Virtual Printer Solution/VirtualPrinter/ViewModels/GlobalSettingsViewModel.cs
+++ b/Src/Virtual Printer Solution/VirtualPrinter/ViewModels/GlobalSettingsViewModel.cs
@@ -123,7 +123,20 @@ namespace VirtualPrinter.ViewModels
 			}
 		}
 
-		public Task InitializeAsync()
+		private string _receivedDataEncoding = "utf-8";
+		public string ReceivedDataEncoding
+		{
+		get
+		{
+			return _receivedDataEncoding;
+		}
+		set
+		{
+			this.SetProperty(ref _receivedDataEncoding, value);
+		}
+		}
+
+    public Task InitializeAsync()
 		{
 			this.ReceiveTimeout = Properties.Settings.Default.ReceiveTimeout;
 			this.SendTimeout = Properties.Settings.Default.SendTimeout;
@@ -132,6 +145,7 @@ namespace VirtualPrinter.ViewModels
 			this.NoDelay = Properties.Settings.Default.NoDelay;
 			this.Linger = Properties.Settings.Default.Linger;
 			this.LingerTime = Properties.Settings.Default.LingerTime;
+			this.ReceivedDataEncoding = Properties.Settings.Default.ReceivedDataEncoding;
 
 			this.RefreshCommands();
 			return Task.CompletedTask;
@@ -146,6 +160,7 @@ namespace VirtualPrinter.ViewModels
 			Properties.Settings.Default.NoDelay = this.NoDelay;
 			Properties.Settings.Default.Linger = this.Linger;
 			Properties.Settings.Default.LingerTime = this.LingerTime;
+			Properties.Settings.Default.ReceivedDataEncoding = this.ReceivedDataEncoding;
 
 			return Task.CompletedTask;
 		}

--- a/Src/Virtual Printer Solution/VirtualPrinter/Views/GlobalSettingsView.xaml
+++ b/Src/Virtual Printer Solution/VirtualPrinter/Views/GlobalSettingsView.xaml
@@ -39,6 +39,7 @@
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
 					</Grid.RowDefinitions>
 
 					<TextBlock Grid.Column="0"
@@ -104,6 +105,20 @@
 							 Text="{Binding LingerTime, Mode=TwoWay}"
 							 Margin="0,5,0,5"
 							 InputScope="NumberFullWidth" />
+
+					<TextBlock Grid.Column="0"
+							   Grid.Row="4"
+							   Text="Received Data Encoding"
+							   Margin="0,5,0,5" />
+					<ComboBox Grid.Column="1"
+							  Grid.Row="4"
+							  Text="{Binding ReceivedDataEncoding, Mode=TwoWay}"
+							  Margin="0,5,5,5"
+							  InputScope="NumberFullWidth"
+							  SelectedIndex="0" >
+						<ComboBoxItem>utf-8</ComboBoxItem>
+						<ComboBoxItem>iso-8859-1</ComboBoxItem>
+					</ComboBox>
 				</Grid>
 			</StackPanel>
 		</GroupBox>


### PR DESCRIPTION
This PR provides two contributions:

- **Avoid randomly splitting large socket messages in multiple ZPL documents**
- **Make encoding of ZPL code in socket messages user-configurable**

The contributions will be explained in more detail in the following:

**Avoid randomly splitting large socket messages in multiple ZPL documents**

The current version of the code assumes that after a new connection is established, each time it retrieves the entire available buffer content from a TCP client socket, the retrieved content represents exactly a single, complete ZPL document. However, this will only work with single/small documents that will be received into the buffer almost atomically. 
In fact, this assumption does not hold for larger or multiple documents that will take longer to be received. Then the receiving buffer will be able to represent a random, partial version of the transmitted document(s) until these are fully received. Rendering these partial versions will then likely produce a vastly different representation in comparison to the original version or could even fail at all.

Similar issues arise if the document is generated on the fly by a client while being sent to the virtual printer, i.e. without being previously cached, so that the document will also be received successively in the buffer. This is also very similar to what could happen if multiple documents are sent to the printer in quick succession.

Unfortunately, the read timeout will be also ignored here, since the current version of the code will only read from the buffer what is already known to be there without ever waiting for additional data of the same document.

The issue can be simply demonstrated when sending the attached file [large_zpl.txt](https://github.com/porrey/Virtual-ZPL-Printer/files/12213521/large_zpl.txt) to the virtual printer, e.g. using `cat large.zpl | nc $printer_ip 9100`. The printer will then fail to render the file.

Therefore, this PR addresses this issue by trying to read everything from the socket using small chunks into a single buffer to give the client enough time to send all data that it wants the virtual printer to handle. This also allows finally applying read timeouts to handle edge cases like unreliable network communication or slow clients.

**Make encoding of ZPL code in socket messages user-configurable**

Windows still largely uses Latin 1 (aka. ISO 8859-1) to encode data. While the first blocks of Latin 1 are identical to UTF-8, trying to decode Latin 1 encoded texts as UTF-8 will start to cause issues as soon as special characters (like the German umlauts) are being used.

The attached file [large_zpl.txt](https://github.com/porrey/Virtual-ZPL-Printer/files/12213521/large_zpl.txt) also contains text with a German umlaut, i.e. the string `München`, encoded in Latin 1. This string will fail to render using UTF-8 encoding as shown here:
<img width="349" alt="Screenshot 2023-07-31 at 11 29 01" src="https://github.com/porrey/Virtual-ZPL-Printer/assets/12437061/dcc2e25d-5ac4-4eb1-87f3-aaf882d3fdff">

In order to avoid fixing the encoding to a single character set, this PR introduces the ability to select the encoding individually in the global program settings.

Only UTF-8 and Latin 1 are offered as available choices so far, but every encoding supported by .NET could be easily added to the selection. The entire list of possible encodings can be found [here](https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding?view=net-7.0#list-of-encodings).

