### PR TITLE
Fix TCP ZPL Template partial read

### DIFF
--- a/Src/Virtual Printer Solution/VirtualPrinter.HostedService.TcpSystem/Models/TcpListenerClientHandler.cs
+++ b/Src/Virtual Printer Solution/VirtualPrinter.HostedService.TcpSystem/Models/TcpListenerClientHandler.cs
@@ -103,8 +103,12 @@ namespace VirtualPrinter.HostedService.TcpSystem
 					ms.Write(data, 0, numBytesRead);
 					this.Logger.LogInformation("{count} byte(s) were read from the incoming connection.", numBytesRead);
 
-					while (stream.DataAvailable && numBytesRead > 0)
+					DateTime startTime = DateTime.Now;
+
+					// We read until data is available and wait for the ^XZ to be received, or for a timeout of 1s to occur.
+					while (stream.DataAvailable || (!encoding.GetString(ms.ToArray(), 0, (int)ms.Length).EndsWith("^XZ") && (DateTime.Now - startTime).TotalMilliseconds < 1000))
 					{
+						await Task.Delay(20);
 						numBytesRead = await stream.ReadAsync(data);
 						ms.Write(data, 0, numBytesRead);
 						this.Logger.LogInformation("{count} additional byte(s) were read from the incoming connection.", numBytesRead);


### PR DESCRIPTION
In the current version, the TCP Listener does not wait for all data to be sent by the client.

The client is a Java application with the Zebra library, the zebra library send the data splitted in 1024 chunk and wait 20ms between chunks.

The Virtual ZPL Printer seems to read 1024 bytes, then see that no data is available and close the connexion, it then show #60 because the ZPL Template is incomplete.
Instead, it should wait (until timeout )for data to come from the client or close the connection if the end of the template ("^XZ") is received

After this modification the problem disappear